### PR TITLE
(GH-285) Fix argumentless execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- [(GH-285)](https://github.com/puppetlabs/pdkgo/issues/285) Ensure running PCT without arguments does not fail unexpectedly.
+
 ## [0.5.0]
 ### Added
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -92,6 +92,10 @@ func InitConfig() {
 // Idea borrowed from carolynvs/porter:
 // https://github.com/carolynvs/porter/blob/ccca10a63627e328616c1006600153da8411a438/cmd/porter/main.go
 func GetCalledCommand(cmd *cobra.Command) (string, string) {
+	if len(os.Args) < 2 {
+		return "", ""
+	}
+
 	calledCommandStr := os.Args[1]
 
 	// Also figure out the full called command from the CLI


### PR DESCRIPTION
Prior to this PR, when running PCT without arguments, the `GetCalledCommand` function would fatally error on an "index out of range failure" because the logic acts on the arguments and always expects at least one.

This PR adds a guard to the `GetCalledCommand` function to return empty strings for subcommand and arguments if no args are passed at the commandline.

Resolves #285 