### PR TITLE
(GH-287) Ensure unconfigured telemetry fails cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [(GH-285)](https://github.com/puppetlabs/pdkgo/issues/285) Ensure running PCT without arguments does not fail unexpectedly.
+- [(GH-287)](https://github.com/puppetlabs/pdkgo/issues/287) Ensure a misconfigured telemetry binary fails early and cleanly.
 
 ## [0.5.0]
 ### Added

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -6,6 +6,7 @@ package telemetry
 import (
 	"context"
 	"runtime"
+	"strings"
 
 	"github.com/denisbrodbeck/machineid"
 	"github.com/rs/zerolog/log"
@@ -63,14 +64,14 @@ func Start(ctx context.Context, honeycomb_api_key string, honeycomb_dataset stri
 			propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}),
 		)
 	} else {
+		var unset_values []string
 		if !api_key_set {
-			log.Info().Msgf("Unable to load honeycomb: API Key must be set and not empty")
+			unset_values = append(unset_values, "API Key")
 		}
 		if !dataset_set {
-			log.Info().Msgf("Unable to load honeycomb: Dataset must be set and not empty")
+			unset_values = append(unset_values, "Dataset")
 		}
-		// should the entire function return here?
-		// No spans will be reported, maybe it's best to return nils or error?
+		log.Fatal().Msgf("Unable to load honeycomb: %s must be set and not empty", strings.Join(unset_values, " and "))
 	}
 
 	tracer := otel.GetTracerProvider().Tracer("")


### PR DESCRIPTION
Prior to this PR, if the Honeycomb API key and/or dataset were not passed at build time, the binary with telemetry would first log warnings about this, then fail esoterically at the end of an execution when attempting to shutdown an uninitialized provider.

This PRmodifies the `Start` function for telemetry to instead write a single clean fatal-level error message if the required values for telemetry have not been set, reducing confusion and unneccessary code execution.

Resolves #287 